### PR TITLE
[FEAT] 자체 회원가입 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@
 /build/
 out/
 
+# macOS
+.DS_Store
+._*
+.AppleDouble
+.LSOverride
+.Spotlight-V100
+.Trashes
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'java'
+    id 'org.springframework.boot' version '3.4.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.app'
@@ -11,12 +13,92 @@ java {
     }
 }
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
 repositories {
     mavenCentral()
 }
 
+def querydslVersion = "5.0.0"
+
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
+
+    // 스프링 부트 기본 의존성
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // DB 드라이버 (MySQL)
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Lombok (컴파일용 + annotation 처리용)
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    testCompileOnly 'org.projectlombok:lombok:1.18.30'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
+
+    // 테스트 관련
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.mockito:mockito-core:5.10.0'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+
+    // 이미지 파일 업로드
+    implementation 'commons-io:commons-io:2.14.0'
+
+    //queryDSL 의존성
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // modelmapper 의존성
+    implementation 'org.modelmapper:modelmapper:2.3.9'
+
+    // 템플릿 엔진 thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    // 스프링 시큐리티
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    // 빈 유효성 검증
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // layout 사용
+    implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.1.0'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // thymeleaf에서 스프링 시큐리티 사용
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+
+    // test에서 스프링 시큐리티 사용
+    testImplementation 'org.springframework.security:spring-security-test'
+}
+
+def querydslDir = "$buildDir/generated/sources/annotaionProcessor/java"
+
+sourceSets {
+    main {
+        java {
+            srcDirs += querydslDir
+        }
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean {
+    delete file(querydslDir)
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
 }
 
 test {

--- a/src/main/java/com/planty/PlantyApplication.java
+++ b/src/main/java/com/planty/PlantyApplication.java
@@ -1,0 +1,11 @@
+package com.planty;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PlantyApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PlantyApplication.class, args);
+    }
+}

--- a/src/main/java/com/planty/common/ApiError.java
+++ b/src/main/java/com/planty/common/ApiError.java
@@ -1,0 +1,19 @@
+package com.planty.common;
+
+import org.springframework.http.ResponseEntity;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+
+// API 에러 규격
+public class ApiError {
+    public static ResponseEntity<Map<String, Object>> of(int status, String code, String message) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", status);
+        body.put("code", code);
+        body.put("message", message);
+        return ResponseEntity.status(status).body(body);
+    }
+}
+

--- a/src/main/java/com/planty/common/ApiSuccess.java
+++ b/src/main/java/com/planty/common/ApiSuccess.java
@@ -1,0 +1,15 @@
+package com.planty.common;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+// 공통 성공 응답 DTO
+@JsonPropertyOrder({ "status", "message" })
+@Getter @AllArgsConstructor
+public class ApiSuccess {
+    private final int status;
+    private final String message;
+}
+

--- a/src/main/java/com/planty/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/planty/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.planty.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.planty.common.ApiError;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+
+// 권한이 없는 사용자
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException ex) throws IOException {
+
+        // 에러 JSON에 넣을 데이터
+        var entity = ApiError.of(403, "FORBIDDEN", "접근 권한이 없습니다.");
+        response.setStatus(403);
+        response.setContentType("application/json;charset=UTF-8");
+
+        // 에러 JSON 삽입
+        om.writeValue(response.getWriter(), entity.getBody());
+    }
+}

--- a/src/main/java/com/planty/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/planty/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,45 @@
+package com.planty.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.planty.common.ApiError;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+
+// 인증되지 않은 사용자 처리
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        // (선택) Bearer 토큰 표준 헤더 — 필요 없으면 삭제 가능
+        // response.setHeader("WWW-Authenticate", "Bearer realm=\"api\", error=\"invalid_token\"");
+
+        // 에러 JSON에 넣을 데이터
+        var entity = ApiError.of(401, "UNAUTHORIZED", "인증되지 않은 사용자입니다.");
+        response.setStatus(401);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        // 에러 JSON 생성
+        om.writeValue(response.getWriter(), entity.getBody());
+    }
+}

--- a/src/main/java/com/planty/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/planty/config/GlobalExceptionHandler.java
@@ -1,0 +1,94 @@
+package com.planty.config;
+
+import com.planty.common.ApiError;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.server.ResponseStatusException;
+
+
+// 전체 예외 처리 클래스
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // DTO @Valid 바디 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValid(MethodArgumentNotValidException ex) {
+        String msg = ex.getBindingResult().getFieldError().getDefaultMessage();
+        return ApiError.of(400, "VALIDATION_ERROR", msg);
+    }
+
+    // 폼/쿼리 파라미터 바인딩 실패
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<?> handleBind(BindException ex) {
+        String msg = ex.getBindingResult().getFieldError().getDefaultMessage();
+        return ApiError.of(400, "BIND_ERROR", msg);
+    }
+
+    // 단건 파라미터(@RequestParam, @PathVariable) 제약 위반
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<?> handleConstraint(ConstraintViolationException ex) {
+        return ApiError.of(400, "CONSTRAINT_VIOLATION", ex.getMessage());
+    }
+
+    // JSON 파싱 오류
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<?> handleNotReadable(HttpMessageNotReadableException ex) {
+        return ApiError.of(400, "INVALID_JSON", "요청 본문(JSON) 형식이 올바르지 않습니다.");
+    }
+
+    // 필수 파라미터 없음
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<?> handleMissing(MissingServletRequestParameterException ex) {
+        return ApiError.of(400, "MISSING_PARAMETER", ex.getParameterName() + " 파라미터가 필요합니다.");
+    }
+
+    // HTTP 메서드 미지원
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<?> handleMethod(HttpRequestMethodNotSupportedException ex) {
+        return ApiError.of(405, "METHOD_NOT_ALLOWED", "지원하지 않는 메서드입니다.");
+    }
+
+    // 커스텀 예외 처리
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<?> handleRSE(ResponseStatusException ex) {
+        String code = ex.getReason(); // "DUPLICATE_USER_ID" 등 서비스에서 실어 보낸 코드
+        String msg  = switch (code) {
+            case "DUPLICATE_USER_ID"   -> "이미 존재하는 아이디입니다.";
+            case "DUPLICATE_NICKNAME"  -> "이미 사용 중인 닉네임입니다.";
+            default -> "요청을 처리할 수 없습니다.";
+        };
+        return ApiError.of(ex.getStatusCode().value(), code != null ? code : "ERROR", msg);
+    }
+
+    // 동시에 회원가입 시 DB에서 터질 때 처리
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<?> handleDataIntegrity(DataIntegrityViolationException ex) {
+        String text = String.valueOf(NestedExceptionUtils.getMostSpecificCause(ex).getMessage());
+
+        if (text.contains("user_id") || text.contains("uk_users_user_id"))
+            return ApiError.of(409, "DUPLICATE_USER_ID", "이미 존재하는 아이디입니다.");
+
+        if (text.contains("nickname") || text.contains("uk_users_nickname"))
+            return ApiError.of(409, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다.");
+
+        return ApiError.of(409, "CONSTRAINT_VIOLATION", "데이터 무결성 위반");
+    }
+
+    // 그 외 예기치 못한 에러
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleEtc(Exception ex) {
+        return ApiError.of(500, "INTERNAL_ERROR", "서버 에러가 발생했습니다.");
+    }
+}
+

--- a/src/main/java/com/planty/config/SecurityConfig.java
+++ b/src/main/java/com/planty/config/SecurityConfig.java
@@ -1,0 +1,133 @@
+package com.planty.config;
+
+import com.planty.service.user.UserService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+// import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+// 보안
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final UserService userService;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+    // (선택) JWT 쓰면 주입해서 아래 addFilterBefore에 등록
+    // private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(
+            UserService userService,
+            CustomAccessDeniedHandler accessDeniedHandler,
+            CustomAuthenticationEntryPoint authenticationEntryPoint
+            // , JwtAuthenticationFilter jwtAuthenticationFilter
+    ) {
+        this.userService = userService;
+        this.accessDeniedHandler = accessDeniedHandler;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        // this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    // 비밀번호 해시 저장
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // 인증 처리기를 인증 로직에서 호출
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // REST API: CSRF 비활성화
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> {}) // 기본값. 필요 시 CorsConfigurationSource 빈 정의해서 커스터마이즈
+
+                // 세션 미사용
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 폼 로그인/로그아웃 제거
+                .formLogin(form -> form.disable())
+                .logout(logout -> logout.disable())
+
+                // 유저 정보 소스
+                .userDetailsService(userService)
+
+                // 권한 매핑
+                .authorizeHttpRequests(auth -> auth
+                        // CORS preflight
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
+                        // 인증 없이 접근 가능한 공개 API
+                        .requestMatchers("/api/users/signup").permitAll()
+                        .requestMatchers("/api/users/login").permitAll()
+
+                        // 어드민 보호
+                        .requestMatchers("/api/admin/**").denyAll()
+
+                        // 나머진 인증 필요
+                        .anyRequest().authenticated()
+                )
+
+                // 예외 처리(JSON 응답)
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                );
+
+        // JWT 사용 시: 사용자 정의 필터 추가
+        // http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        // JWT 준비 전, 임시로 Basic 인증으로 개발 테스트 가능 (원하면 주석 해제)
+        // http.httpBasic(Customizer.withDefaults());
+
+        return http.build();
+    }
+
+    // CORS 설정
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        // 허용 주소 설정
+        config.setAllowedOriginPatterns(List.of("http://localhost:*", "http://127.0.0.1:*"));
+
+        // 허용 메서드 설정
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+
+        // 헤더 목록 설정
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+
+        // 브라우저 자격 증명 허용
+        config.setAllowCredentials(true);
+
+        // 권한 헤더를 읽을 수 있게 설정
+        config.setExposedHeaders(List.of("Authorization"));
+
+        // URL 패턴에 따라 서로 다른 CORS 정책 적용
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}

--- a/src/main/java/com/planty/controller/MainController.java
+++ b/src/main/java/com/planty/controller/MainController.java
@@ -1,0 +1,16 @@
+package com.planty.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+@Controller
+@RequiredArgsConstructor
+public class MainController {
+
+    @GetMapping(value = "/")
+    public String main(){
+        return "main";
+    }
+}

--- a/src/main/java/com/planty/controller/user/UserController.java
+++ b/src/main/java/com/planty/controller/user/UserController.java
@@ -1,0 +1,34 @@
+package com.planty.controller.user;
+
+import com.planty.common.ApiSuccess;
+import com.planty.dto.user.SignupFormDto;
+import com.planty.entity.user.User;
+import com.planty.service.user.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+
+    // 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@Valid @RequestBody SignupFormDto signupFormDto) {
+        // 비밀번호 해시 + 저장
+        User user = User.createUser(signupFormDto, passwordEncoder);
+        userService.saveUser(user);
+
+        // 컨벤션: 데이터 없을 때 status + message
+        return ResponseEntity.status(201).body(new ApiSuccess(201, "성공적으로 처리되었습니다."));
+    }
+}

--- a/src/main/java/com/planty/dto/mypage/ProfileFormDto.java
+++ b/src/main/java/com/planty/dto/mypage/ProfileFormDto.java
@@ -1,0 +1,5 @@
+package com.planty.dto.mypage;
+
+
+public class ProfileFormDto {
+}

--- a/src/main/java/com/planty/dto/user/SignupFormDto.java
+++ b/src/main/java/com/planty/dto/user/SignupFormDto.java
@@ -1,0 +1,19 @@
+package com.planty.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+
+// 프론트 연결용 DTO
+@Getter @Setter
+public class SignupFormDto {
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String userId;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    private String nickname;
+}

--- a/src/main/java/com/planty/entity/user/BlockUser.java
+++ b/src/main/java/com/planty/entity/user/BlockUser.java
@@ -1,0 +1,36 @@
+package com.planty.entity.user;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+
+// 차단한 유저
+@Entity
+@Table(name = "BlockUser")
+@Getter @Setter
+public class BlockUser {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true, nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "block_id", unique = true, nullable = false) // FK
+    private User blocked;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/com/planty/entity/user/User.java
+++ b/src/main/java/com/planty/entity/user/User.java
@@ -1,0 +1,62 @@
+package com.planty.entity.user;
+
+import com.planty.dto.user.SignupFormDto;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Entity
+@Table(name = "users")
+@Getter @Setter
+@ToString
+public class User {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false)
+    private String userId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    private Integer point = 0;
+    private String profileImg;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BlockUser> blocks = new ArrayList<>();
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime modifiedAt;
+
+    // 회원가입
+    public static User createUser(SignupFormDto signupFormDto, PasswordEncoder passwordEncoder) {
+        // 유저 객체 생성
+        User user = new User();
+
+        // 회원가입 데이터 세팅
+        user.setUserId(signupFormDto.getUserId());
+        String pwd = passwordEncoder.encode(signupFormDto.getPassword());
+        user.setPassword(pwd);
+        user.setNickname(signupFormDto.getNickname());
+
+        // 반환
+        return user;
+    }
+}

--- a/src/main/java/com/planty/repository/user/UserRepository.java
+++ b/src/main/java/com/planty/repository/user/UserRepository.java
@@ -1,0 +1,20 @@
+package com.planty.repository.user;
+
+import com.planty.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer> {
+    // 유저 ID 로그인
+    Optional<User> findByUserId(String userId);
+
+    // 유저 아이디 중복 검사
+    boolean existsByUserId(String userId);
+
+    // 유저 닉네임 중복 검사
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/planty/service/user/UserService.java
+++ b/src/main/java/com/planty/service/user/UserService.java
@@ -1,0 +1,62 @@
+package com.planty.service.user;
+
+import com.planty.entity.user.User;
+import com.planty.repository.user.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+
+// 회원가입, 로그인, 로그아웃
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    // 회원가입
+    public User saveUser(User user) {
+        validateDuplicateId(user);
+        validateDuplicateNickname(user);
+        return userRepository.save(user);
+    }
+
+    // userId 중복 확인
+    private void validateDuplicateId(User user) {
+        if (userRepository.existsByUserId(user.getUserId())) {
+            throw new ResponseStatusException(CONFLICT, "DUPLICATE_USER_ID");
+        }
+    }
+
+    // 닉네임 중복 확인
+    private void validateDuplicateNickname(User user) {
+        if (userRepository.existsByNickname(user.getNickname())) {
+            throw new ResponseStatusException(CONFLICT, "DUPLICATE_NICKNAME");
+        }
+    }
+
+    // 로그인 시 호출되는 메서드
+    @Override
+    @Transactional(Transactional.TxType.SUPPORTS)
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User u = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + userId));
+
+        // 권한 없이 기본 USER 권한만 부여
+        return new org.springframework.security.core.userdetails.User(
+                u.getUserId(),
+                u.getPassword(),
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,28 @@
+spring:
+  application:
+    name: Centralthon
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/Centralthon?serverTimezone=UTC
+    username: back
+    password: 1234
+
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    hibernate:
+      ddl-auto: none
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    generate-ddl: false
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: debug
+        type:
+          descriptor:
+            sql: trace

--- a/src/test/java/com/planty/repository/user/UserRepositoryTest.java
+++ b/src/test/java/com/planty/repository/user/UserRepositoryTest.java
@@ -1,0 +1,28 @@
+package com.planty.repository.user;
+
+import com.planty.entity.user.User;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = "classpath:application.yml")
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void testSaveUser() {
+        User user = new User();
+        user.setUserId("testUser");
+        user.setPassword("pass");
+        user.setNickname("nickname");
+        userRepository.save(user);
+
+        System.out.println(user.toString());
+    }
+}


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
- 회원가입 및 유저 데이터 DB에 저장

---

## 📋 구현 내용
<!-- 기능 설계서와 비교하여 구현한 내용을 정리해주세요 -->
- 설계서에 따른 주요 기능 구현
(1) 회원가입
(2) 아이디, 닉네임 중복 처리

- API 엔드포인트 및 파라미터 (/users/signup)
- 로직 처리 순서

---

## 🔗 관련 참고 자료

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->
- common 폴더에 공통 api 실패/성공 응답을 넣어두었습니다.
- config/GlobalExceptionHandler에 기본 예외 처리 목록들을 넣어두었습니다.
- controller, dto, entity, repository, service에 user 폴더 내에서 회원가입 작업했습니다.

---

## 🧪 테스트 내용
<!-- 동작 테스트 방법과 결과 -->
- [x] 단위 테스트 작성 및 통과
- [x] 로컬 환경 실행 확인
- [x] 주요 기능 시나리오 테스트 완료

---

## 📷 스크린샷/시연 영상
<!-- UI 변경 시 이미지, API 응답 예시, 콘솔 출력 등 첨부 -->
<img width="643" height="677" alt="image" src="https://github.com/user-attachments/assets/7181f171-385d-46a2-aaa6-0f249b785029" />

---

## ✅ 체크리스트
- [x] 기능 설계서의 요구사항을 모두 반영했는가?
- [x] 예외 케이스를 처리했는가?
- [x] 코드 컨벤션을 준수했는가?
- [x] 리뷰어 피드백을 반영했는가?

---

## 📝 비고
<!-- 추가로 전달할 사항 -->
