### PR TITLE
[FEAT] 자체 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,14 @@ dependencies {
 
     // test에서 스프링 시큐리티 사용
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // jwt 토큰
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly  'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly  'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // application.yml jwt 인식
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 def querydslDir = "$buildDir/generated/sources/annotaionProcessor/java"

--- a/src/main/java/com/planty/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/planty/config/GlobalExceptionHandler.java
@@ -59,13 +59,14 @@ public class GlobalExceptionHandler {
         return ApiError.of(405, "METHOD_NOT_ALLOWED", "지원하지 않는 메서드입니다.");
     }
 
-    // 커스텀 예외 처리
+    // 회원가입/로그인 에러 처리
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<?> handleRSE(ResponseStatusException ex) {
         String code = ex.getReason(); // "DUPLICATE_USER_ID" 등 서비스에서 실어 보낸 코드
         String msg  = switch (code) {
             case "DUPLICATE_USER_ID"   -> "이미 존재하는 아이디입니다.";
             case "DUPLICATE_NICKNAME"  -> "이미 사용 중인 닉네임입니다.";
+            case "INVALID_CREDENTIALS" -> "아이디 또는 비밀번호가 올바르지 않습니다.";
             default -> "요청을 처리할 수 없습니다.";
         };
         return ApiError.of(ex.getStatusCode().value(), code != null ? code : "ERROR", msg);
@@ -84,6 +85,7 @@ public class GlobalExceptionHandler {
 
         return ApiError.of(409, "CONSTRAINT_VIOLATION", "데이터 무결성 위반");
     }
+
 
     // 그 외 예기치 못한 에러
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/planty/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/planty/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+// src/main/java/com/planty/config/jwt/JwtAuthenticationFilter.java
+package com.planty.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Set;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UserDetailsService userDetailsService;
+    private final Set<String> whitelist = Set.of(
+            "/api/users/login",
+            "/api/users/signup"
+    );
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider, UserDetailsService userDetailsService) {
+        this.jwtProvider = jwtProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    // 화이트리스트는 필터 건너뜀
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        // OPTIONS (CORS preflight)도 스킵
+        return "OPTIONS".equalsIgnoreCase(request.getMethod()) || whitelist.contains(path);
+    }
+
+    // 인증 로직
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            String token = bearer.substring(7);
+
+            try {
+                // 1) 토큰에서 userId(subject) 추출 (서명/만료 검증 포함)
+                String userId = jwtProvider.getSubject(token);
+
+                // 2) DB에서 유저 로드
+                UserDetails user = userDetailsService.loadUserByUsername(userId);
+
+                // 3) 인증 객체 생성해서 컨텍스트에 저장
+                var auth = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(auth);
+
+            } catch (Exception ex) {
+                // 토큰이 유효하지 않으면 인증 컨텍스트를 비운 채로 통과 → 뒤에서 401 처리됨
+                SecurityContextHolder.clearContext();
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/planty/config/jwt/JwtProvider.java
+++ b/src/main/java/com/planty/config/jwt/JwtProvider.java
@@ -1,0 +1,88 @@
+package com.planty.config.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.regex.Pattern;
+
+
+// JWT 발급 및 파싱
+@Component
+public class JwtProvider {
+
+    private final String secretRaw;
+    private final long accessExpMillis;
+    private Key key;
+
+    // jwt.secret, jwt.access-exp-millis 필드에 저장
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-exp-millis}") long accessExpMillis
+    ) {
+        this.secretRaw = secret;
+        this.accessExpMillis = accessExpMillis;
+    }
+
+    // Base64 형태인지 판별 (문자셋+패딩)
+    private static final Pattern BASE64_PATTERN = Pattern.compile("^[A-Za-z0-9+/=\\r\\n]+$");
+
+    // JWT 서명용 Key 객체 생성
+    @PostConstruct
+    void init() {
+        if (secretRaw == null || secretRaw.isBlank()) {
+            throw new IllegalStateException("jwt.secret 가 비어있음 (application.yml/profiles 확인)");
+        }
+
+        // Base64의 시크릿 키를 디코딩해서 byte[]나 UTF-8로 변환
+        byte[] keyBytes;
+        if (looksLikeBase64(secretRaw)) {
+            keyBytes = Decoders.BASE64.decode(secretRaw);
+        } else {
+            keyBytes = secretRaw.getBytes(StandardCharsets.UTF_8);
+        }
+
+        // HS256 최소 권장 키 길이 검증
+        if (keyBytes.length < 32) {
+            throw new IllegalStateException(
+                    "jwt.secret 길이가 너무 짧음: " + keyBytes.length + " bytes (최소 32 bytes 필요)"
+            );
+        }
+
+        // HMAC-SHA용 Key 객체로 변환
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // Base64 문자열 판별
+    private boolean looksLikeBase64(String s) {
+        // 길이 4 배수 & 허용 문자만
+        int len = s.replace("\r", "").replace("\n", "").length();
+        return len % 4 == 0 && BASE64_PATTERN.matcher(s).matches();
+    }
+
+    // JWT 액세스 토큰 발급
+    public String createAccessToken(String userId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(userId) // 토큰 주인
+                .setIssuedAt(now)   // 발급 시간
+                .setExpiration(new Date(now.getTime() + accessExpMillis))   // 만료 시간
+                .signWith(key, SignatureAlgorithm.HS256)    // 키와 알고리즘으로 서명
+                .compact(); // 최종 문자열 토큰 생성
+    }
+
+    // 토큰 검증 및 userId 반환
+    public String getSubject(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/src/main/java/com/planty/controller/user/UserController.java
+++ b/src/main/java/com/planty/controller/user/UserController.java
@@ -1,15 +1,23 @@
 package com.planty.controller.user;
 
 import com.planty.common.ApiSuccess;
+import com.planty.config.jwt.JwtProvider;
+import com.planty.dto.user.LoginFormDto;
 import com.planty.dto.user.SignupFormDto;
 import com.planty.entity.user.User;
 import com.planty.service.user.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 
@@ -20,6 +28,7 @@ public class UserController {
 
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
 
     // 회원가입
     @PostMapping("/signup")
@@ -30,5 +39,39 @@ public class UserController {
 
         // 컨벤션: 데이터 없을 때 status + message
         return ResponseEntity.status(201).body(new ApiSuccess(201, "성공적으로 처리되었습니다."));
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@Valid @RequestBody LoginFormDto loginFormDto) {
+
+        UserDetails user;
+
+        // id로 유저 조회
+        try {
+            user = userService.loadUserByUsername(loginFormDto.getUserId());
+        } catch (UsernameNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS");
+        }
+
+        // 입력된 비번과 저장된 해시 비교
+        if (!passwordEncoder.matches(loginFormDto.getPassword(), user.getPassword())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS");
+        }
+
+        // JWT 발급
+        String accessToken  = jwtProvider.createAccessToken(user.getUsername());
+
+        // JSON 응답 데이터
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", 200);
+        body.put("message", "로그인 성공");
+        body.put("accessToken", accessToken);
+
+        // JSON 응답 생성
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .body(body);
+
     }
 }

--- a/src/main/java/com/planty/dto/user/LoginFormDto.java
+++ b/src/main/java/com/planty/dto/user/LoginFormDto.java
@@ -1,0 +1,16 @@
+package com.planty.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+
+// 프론트 로그인용 DTO
+@Getter @Setter
+public class LoginFormDto {
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String userId;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,8 @@ logging:
         type:
           descriptor:
             sql: trace
+
+jwt:
+  secret: "change-this-to-a-very-long-random-secret-at-least-256-bits"
+  access-exp-millis: 86400000     # 1시간
+


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
- 자체 로그인 구현

---

## 📋 구현 내용
<!-- 기능 설계서와 비교하여 구현한 내용을 정리해주세요 -->
- 설계서에 따른 주요 기능 구현
(1) 로그인
(2) JWT 토큰 발급
(3) JWT 토큰으로 유저 정보 받아오기

- API 엔드포인트 및 파라미터(/users/login)

- 로직 처리 순서

---

## 🔗 관련 참고 자료

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->
- 

---

## 🧪 테스트 내용
<!-- 동작 테스트 방법과 결과 -->
- [ ] 단위 테스트 작성 및 통과
- [ ] 로컬 환경 실행 확인
- [ ] 주요 기능 시나리오 테스트 완료

---

## 📷 스크린샷/시연 영상
<!-- UI 변경 시 이미지, API 응답 예시, 콘솔 출력 등 첨부 -->
<img width="1311" height="781" alt="image" src="https://github.com/user-attachments/assets/77f95bf2-f4af-4cd4-8c0e-5395a97f5048" />


---

## ✅ 체크리스트
- [x] 기능 설계서의 요구사항을 모두 반영했는가?
- [x] 예외 케이스를 처리했는가?
- [x] 코드 컨벤션을 준수했는가?
- [ ] 리뷰어 피드백을 반영했는가?

---

## 📝 비고
<!-- 추가로 전달할 사항 -->
- JWT 토큰 발급했습니다. 앞으로 api 명세서 작성하실 때 Request Header에 Bearer로 넣어주시면 됩니다.
- 로그인, 회원가입 외의 기능 사용 시 반드시 토큰 인증이 되어야 넘어갈 수 있도록 했습니다.