### PR TITLE
[FEAT] 판매 게시글 판매 상태 변경

### DIFF
--- a/src/main/java/com/planty/controller/board/BoardController.java
+++ b/src/main/java/com/planty/controller/board/BoardController.java
@@ -4,23 +4,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.planty.common.ApiSuccess;
 import com.planty.config.CustomUserDetails;
-import com.planty.dto.board.BoardDetailResDto;
-import com.planty.dto.board.BoardFormDto;
-import com.planty.dto.board.BoardSaveFormDto;
-import com.planty.dto.board.BoardSellCropsDto;
-import com.planty.entity.board.Board;
-import com.planty.entity.board.BoardImage;
-import com.planty.repository.board.BoardRepository;
-import com.planty.repository.crop.CropRepository;
-import com.planty.repository.user.UserRepository;
+import com.planty.dto.board.*;
 import com.planty.service.board.BoardService;
-import com.planty.service.user.UserService;
 import com.planty.storage.StorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,7 +18,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 
 // 판매 게시판
@@ -147,6 +136,23 @@ public class BoardController {
 
         // (4) 업데이트
         boardService.updateBoard(id, me.getId(), dto, keepImageUrls);
+
+        // 성공 json 반환
+        return ResponseEntity.ok(new ApiSuccess(200, "성공적으로 처리되었습니다."));
+    }
+
+    // 판매 게시글 판매 상태 수정
+    @PatchMapping(value="/{id:\\d+}")
+    public ResponseEntity<?> updateSellStatus(
+            @AuthenticationPrincipal CustomUserDetails me,
+            @PathVariable Integer id,
+            @RequestBody SellStatusFormDto sellStatusFormDto
+    ) throws IOException {
+        // 권한이 없을 때
+        if (me == null) return ResponseEntity.status(401).build();
+
+        // 판매 상태 업데이트
+        boardService.updateSellStatus(id, me.getId(), sellStatusFormDto.getSellStatus());
 
         // 성공 json 반환
         return ResponseEntity.ok(new ApiSuccess(200, "성공적으로 처리되었습니다."));

--- a/src/main/java/com/planty/dto/board/SellStatusFormDto.java
+++ b/src/main/java/com/planty/dto/board/SellStatusFormDto.java
@@ -1,0 +1,10 @@
+package com.planty.dto.board;
+
+import lombok.Getter;
+
+
+// 프론트가 판매 상태 보내는 용도
+@Getter
+public class SellStatusFormDto {
+    private Boolean sellStatus;
+}

--- a/src/main/java/com/planty/service/board/BoardService.java
+++ b/src/main/java/com/planty/service/board/BoardService.java
@@ -213,4 +213,25 @@ public class BoardService {
             images.get(0).setThumbnail(true);
         }
     }
+
+    // 판매 상태 변경
+    public void updateSellStatus(Integer boardId,
+                            Integer meId,
+                            Boolean sellStatus) {    // 유지할 기존 이미지 URL 목록 (null이면 유지 없음)
+
+        // 1) 대상 게시글 조회
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "NOT_FOUND"));
+
+        // 2) 소유자 검증
+        if (!board.getUser().getId().equals(meId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "FORBIDDEN");
+        }
+
+        // 판매 상태 변경
+        board.setSell(sellStatus);
+
+        // 5) 저장
+        boardRepository.save(board);
+    }
 }


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
- 판매 게시글 판매 상태 변경

---

## 📋 구현 내용
<!-- 기능 설계서와 비교하여 구현한 내용을 정리해주세요 -->
- 설계서에 따른 주요 기능 구현
(1) 판매 게시글 판매 상태 변경

- API 엔드포인트 및 파라미터 (/board/{id})

- 로직 처리 순서

---

## 🔗 관련 참고 자료

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->

---

## 🧪 테스트 내용
<!-- 동작 테스트 방법과 결과 -->
- [x] 단위 테스트 작성 및 통과
- [x] 로컬 환경 실행 확인
- [x] 주요 기능 시나리오 테스트 완료

---

## 📷 스크린샷/시연 영상
<!-- UI 변경 시 이미지, API 응답 예시, 콘솔 출력 등 첨부 -->
<img width="823" height="681" alt="image" src="https://github.com/user-attachments/assets/eb3be164-c24a-44d5-879f-1f147d9ba747" />


---

## ✅ 체크리스트
- [x] 기능 설계서의 요구사항을 모두 반영했는가?
- [x] 예외 케이스를 처리했는가?
- [x] 코드 컨벤션을 준수했는가?
- [x] 리뷰어 피드백을 반영했는가?

---

## 📝 비고
<!-- 추가로 전달할 사항 -->
- 현재 판매 게시글 내에서 판매 중, 판매 완료, 취소 버튼이 있습니다. Boolean으로는 판매 중과 판매 완료만 판단할 수 있어서, 취소 버튼의 필요성을 8월 15일 회의 때 이야기하겠습니다.