### PR TITLE
[feat] : 썸네일 추가

### DIFF
--- a/src/main/java/com/planty/controller/diary/DiaryController.java
+++ b/src/main/java/com/planty/controller/diary/DiaryController.java
@@ -50,6 +50,12 @@ public class DiaryController {
         // 권한이 없을 때
         if (me == null) return ResponseEntity.status(401).build();
 
+        // 이미지 개수 검증 (최대 3개)
+        if (images != null && images.size() > 3) {
+            return ResponseEntity.badRequest()
+                    .body(new ApiSuccess(400, "이미지는 최대 3개까지만 업로드할 수 있습니다."));
+        }
+
         // 파일 저장 → URL 리스트 생성
         List<String> urls = new ArrayList<>();
         if (images != null) {
@@ -58,6 +64,12 @@ public class DiaryController {
                     urls.add(storageService.save(f, "diary"));
                 }
             }
+        }
+
+        // 이미지 URL 개수 재검증 (빈 파일 제외 후)
+        if (urls.size() > 3) {
+            return ResponseEntity.badRequest()
+                    .body(new ApiSuccess(400, "유효한 이미지는 최대 3개까지만 업로드할 수 있습니다."));
         }
 
         // 서비스 호출

--- a/src/main/java/com/planty/dto/diary/DiaryDetailDto.java
+++ b/src/main/java/com/planty/dto/diary/DiaryDetailDto.java
@@ -16,6 +16,7 @@ public class DiaryDetailDto {
     private String content;
     private String analysis;
     private List<String> images;
+    private String thumbnailImage; // 썸네일 이미지 URL
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 }


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
- 재배일지 작성 시 3개의 이미지 등록 가능 및 첫번째 사진 -> 썸네일로 연결

## 📋 구현 내용
<!-- 기능 설계서와 비교하여 구현한 내용을 정리해주세요 -->


## 🔗 관련 참고 자료

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->

---

## 🧪 테스트 내용
<!-- 동작 테스트 방법과 결과 -->
- [ ] 단위 테스트 작성 및 통과
- [ ] 로컬 환경 실행 확인
- [ ] 주요 기능 시나리오 테스트 완료

--- 이거 일단 재배일지 CRUD 완성 후 디버깅 이슈에 한번에 업로드 예정입니다

## 📷 스크린샷/시연 영상
<!-- UI 변경 시 이미지, API 응답 예시, 콘솔 출력 등 첨부 -->
- 

---

## ✅ 체크리스트
- [ ] 기능 설계서의 요구사항을 모두 반영했는가?
- [ ] 예외 케이스를 처리했는가?
- [ ] 코드 컨벤션을 준수했는가?
- [ ] 리뷰어 피드백을 반영했는가?

---

## 📝 비고
<!-- 추가로 전달할 사항 -->
## **📋 재배일지 API 테스트 가이드**

**🔗 Base URL http://localhost:8080/**

**📝 API 목록**

**1. 재배일지 작성용 작물 목록 조회**

- **GET /api/diary/crops**

**2. 재배일지 작성**

- **POST /api/diary/Content-Type: multipart/form-data**

**3. 재배일지 상세 조회**

- **GET /api/diary/details/{id}**

**4. 내 재배일지 목록**

- **GET /api/diary/my**

**5. 특정 사용자 재배일지 목록**

- **GET /api/diary/user/{userId}**

**6. 작물별 재배일지 목록**

- **GET** /api/diary/crop/{cropId}
